### PR TITLE
Revised program styling.

### DIFF
--- a/program.php
+++ b/program.php
@@ -10,6 +10,16 @@
     <title>
       <?php echo $META['shortName'];?> Program
     </title>
+    <style>
+      #renderedProgram a.nav-link {
+        color: green;
+      }
+     #renderedProgram .track1Event,
+     #renderedProgram .track2Event,
+     #renderedProgram .mutualEvent {
+       padding: 1rem;
+     }
+    </style>
   </head>
   <body>
     <?php require "includes/nav.php"; ?>
@@ -20,13 +30,15 @@
       </h2>
 
       <!-- NOTE: below is placeholder content derived from the Crypto 2016 conference. remove and replace with your own content when ready. this code is here to give you an idea of what the structure of this page has looked like in the past
-           <div class="row">
-             <aside class="col-12">
-               <p>
-                 All track 1 events at this fictitious conference will take place in Corwin Pavilion, while all track 2 events are in Lotte Lehmann Hall, unless otherwise noted. Track 1 events have a green background and track 2 events have an orange background. Events for everyone or those that are not assigned to a particular track have a light blue background.
-               </p>
-             </aside>
-           </div>
+           <p>
+             All track 1 events at this fictitious conference will
+             take place in Corwin Pavilion, while all track 2 events
+             are in Lotte Lehmann Hall, unless otherwise noted. Track
+             1 events have a green background and track 2 events have
+             an orange background. Events for everyone or those that
+             are not assigned to a particular track have a light blue
+             background.
+           </p>
            -->
 
       <div class="row">
@@ -37,8 +49,8 @@
             <div role="navigation">
               <ul class="nav nav-tabs nav-justified">
                 {{#each days}}
-                <li role="presentation">
-                  <a href="#day-{{date}}">
+                <li role="presentation nav-item">
+                  <a href="#day-{{date}}" class="nav-link">
                     {{formatDate date}}
                   </a>
                 </li>
@@ -64,11 +76,11 @@
               </div>
               {{#if twosessions}}
               <div class="col-10 col-sm-5">
-                <div class="track1Event panel-body">
+                <div class="track1Event">
                   <h4 class="text-center">
                     {{sessions.0.session_title}}
                     {{#if sessions.0.session_url}}
-                    &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/info.svg" title="Session Info"></a>
+                    &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
                   </h4>
                   {{#if sessions.0.location.name}}
@@ -92,29 +104,29 @@
                   </p>
                   {{#if paperUrl}}
                   <span class="talkMedia">
-                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/file.svg" title="Paper"></a>
+                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/icons/file.svg" title="Paper"></a>
                   </span>
                   {{/if}}
                   {{#if slidesUrl}}
                   <span class="talkMedia">
-                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/presentation.svg" title="Slides"></a>
+                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/icons/presentation.svg" title="Slides"></a>
                   </span>
                   {{/if}}
                   {{/each}}
                 </div>
               </div>
-              <!-- TODO: hidden-sm and etc may no longer be functional/necessary -->
-              <div class="col-2 hidden-sm hidden-md hidden-lg">
+              <!-- This is visible only on mobile, when sessions wrap -->
+              <div class="col-2 d-sm-block d-md-none">
                 <p class="timeSlot">
                   {{starttime}}-{{endtime}}
                 </p>
               </div>
               <div class="col-10 col-sm-5">
-                <div class="panel-body track2Event">
+                <div class="track2Event">
                   <h4 class="text-center">
                     {{sessions.1.session_title}}
                     {{#if sessions.1.session_url}}
-                    &nbsp; <a href="{{sessions.1.session_url}}"><img class="sessionInfoIcon" src="images/info.svg" title="Session Info"></a>
+                    &nbsp; <a href="{{sessions.1.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
                   </h4>
                   {{#if sessions.1.location.name}}
@@ -138,12 +150,12 @@
                   </p>
                   {{#if paperUrl}}
                   <span class="talkMedia">
-                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/file.svg" title="Paper"></a>
+                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/icons/file.svg" title="Paper"></a>
                   </span>
                   {{/if}}
                   {{#if slidesUrl}}
                   <span class="talkMedia">
-                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/presentation.svg" title="Slides"></a>
+                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/icons/presentation.svg" title="Slides"></a>
                   </span>
                   {{/if}}
                   {{/each}}
@@ -151,11 +163,11 @@
               </div>
               {{else}}
               <div class="col-10">
-                <div class="panel-body mutualEvent">
+                <div class="mutualEvent">
                   <h4>
                     {{sessions.0.session_title}}
                     {{#if sessions.0.session_url}}
-                    &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/info.svg" title="Session Info"></a>
+                    &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
                   </h4>
                   {{#if sessions.0.location.name}}
@@ -179,12 +191,12 @@
                   </p>
                   {{#if paperUrl}}
                   <span class="talkMedia">
-                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/file.svg" title="Paper"></a>
+                    Media: &nbsp; <a href="{{paperUrl}}"><img class="talkMediaIcon" src="images/icons/file.svg" title="Paper"></a>
                   </span>
                   {{/if}}
                   {{#if slidesUrl}}
                   <span class="talkMedia">
-                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/presentation.svg" title="Slides"></a>
+                    &nbsp; <a href="{{slidesUrl}}"><img class="talkMediaIcon" src="images/icons/presentation.svg" title="Slides"></a>
                   </span>
                   {{/if}}
                   {{/each}}

--- a/program.php
+++ b/program.php
@@ -49,7 +49,7 @@
             <div role="navigation">
               <ul class="nav nav-tabs nav-justified">
                 {{#each days}}
-                <li role="presentation nav-item">
+                <li role="presentation" class="nav-item">
                   <a href="#day-{{date}}" class="nav-link">
                     {{formatDate date}}
                   </a>

--- a/program.php
+++ b/program.php
@@ -77,12 +77,12 @@
               {{#if twosessions}}
               <div class="col-10 col-sm-5">
                 <div class="track1Event">
-                  <h4 class="text-center">
+                  <h5 class="text-center">
                     {{sessions.0.session_title}}
                     {{#if sessions.0.session_url}}
                     &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
-                  </h4>
+                  </h5>
                   {{#if sessions.0.location.name}}
                   <p class="dualTrackDescr">
                     {{sessions.0.location.name}}
@@ -123,12 +123,12 @@
               </div>
               <div class="col-10 col-sm-5">
                 <div class="track2Event">
-                  <h4 class="text-center">
+                  <h5 class="text-center">
                     {{sessions.1.session_title}}
                     {{#if sessions.1.session_url}}
                     &nbsp; <a href="{{sessions.1.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
-                  </h4>
+                  </h5>
                   {{#if sessions.1.location.name}}
                   <p class="dualTrackDescr">
                     {{sessions.1.location.name}}
@@ -164,12 +164,12 @@
               {{else}}
               <div class="col-10">
                 <div class="mutualEvent">
-                  <h4>
+                  <h5>
                     {{sessions.0.session_title}}
                     {{#if sessions.0.session_url}}
                     &nbsp; <a href="{{sessions.0.session_url}}"><img class="sessionInfoIcon" src="images/icons/info.svg" title="Session Info"></a>
                     {{/if}}
-                  </h4>
+                  </h5>
                   {{#if sessions.0.location.name}}
                   <p class="eventDescr">
                     {{sessions.0.location.name}}

--- a/program.php
+++ b/program.php
@@ -11,13 +11,13 @@
       <?php echo $META['shortName'];?> Program
     </title>
     <style>
-      #renderedProgram a.nav-link {
-        color: green;
-      }
      #renderedProgram .track1Event,
      #renderedProgram .track2Event,
      #renderedProgram .mutualEvent {
        padding: 1rem;
+     }
+     ul.nav .nav-link:hover {
+       background-color: #eeeeee;
      }
     </style>
   </head>

--- a/styles/main.css
+++ b/styles/main.css
@@ -386,6 +386,10 @@ img.talkMediaIcon, img.sessionInfoIcon {
   height: 20px;
 }
 
+img.sessionInfoIcon {
+  vertical-align: unset;
+}
+
 
 
 /***** Page-specific: sponsors *****/

--- a/styles/main.css
+++ b/styles/main.css
@@ -58,7 +58,7 @@ a:hover {
   }
 }
 
-a.nav-link {
+.navbar-nav a.nav-link {
   color: #FEFDFB;
   font-size: 1.2rem;
 }


### PR DESCRIPTION
I've tried to keep the changes to a minimum. A demo is online at https://mccurley.org/iacr2/ using the Asiacrypt 2019 program. There are only a few things dictated by the bootstrap 3=>4 migration.

As it turns out, I think it might be possible to use a much simpler template that does not use the twosessions hack, but I've avoided putting it into this pull request. The idea is to remove twosessions, and have
{{#each session}}
... the dom for a session
{{/each}}
Then we can change the styling on the session based on how many sessions there are.

There are two ways to do this that I can think of:

1. use an [ifCond helper](https://stackoverflow.com/questions/28978759/length-check-in-a-handlebars-js-if-conditional/28978858) in handlebars to test when the length of sessions is > 1. Then use this helper to apply either col-10 or col-5 on the session. We don't need track1Event and track2Event classes, because we could use css selectors to style the two nodes differently (e.g., nth-child(2)).
2. use only css selectors to style the node based on [how many siblings it has](https://stackoverflow.com/questions/8720931/can-css-detect-the-number-of-children-an-element-has). The only disadvantage of this technique is that we could not switch on the length to apply col-5 classes. I would prefer to keep the bootstrap grid classes, so I don't favor this technique.